### PR TITLE
Add BigQuery timestamp lookup notebook variations

### DIFF
--- a/notebooks/variation1_bq_utils.ipynb
+++ b/notebooks/variation1_bq_utils.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BigQuery Timestamp Fetch (bq_utils helper)\n",
+    "Reads `data/input/seeds.csv` and retrieves block timestamps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from src.bq_utils import get_bigquery_client, fetch_tx_timestamps\n",
+    "\n",
+    "seeds = pd.read_csv('../data/input/seeds.csv', header=None)[0].tolist()\n",
+    "client = get_bigquery_client()\n",
+    "timestamps = fetch_tx_timestamps(client, seeds)\n",
+    "pd.DataFrame(list(timestamps.items()), columns=['txid', 'timestamp']).head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/variation2_direct_sql.ipynb
+++ b/notebooks/variation2_direct_sql.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BigQuery Timestamp Fetch (direct SQL)\n",
+    "Reads `data/input/seeds.csv` and retrieves block timestamps using direct BigQuery SQL queries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from google.cloud import bigquery\n",
+    "\n",
+    "seeds = pd.read_csv('../data/input/seeds.csv', header=None)[0].tolist()\n",
+    "client = bigquery.Client()\n",
+    "sql = \"\"\"\nSELECT TO_HEX(`hash`) AS txid, block_timestamp\nFROM `bigquery-public-data.crypto_bitcoin.transactions`\nWHERE TO_HEX(`hash`) IN UNNEST(@txids)\n\"\"\"\n",
+    "job_config = bigquery.QueryJobConfig(query_parameters=[bigquery.ArrayQueryParameter('txids','STRING',seeds)])\n",
+    "rows = client.query(sql, job_config=job_config).result()\n",
+    "timestamps = {row.txid: row.block_timestamp.isoformat() for row in rows}\n",
+    "pd.DataFrame.from_dict(timestamps, orient='index', columns=['timestamp']).head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/variation3_pandas_gbq.ipynb
+++ b/notebooks/variation3_pandas_gbq.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BigQuery Timestamp Fetch (pandas_gbq)\n",
+    "Reads `data/input/seeds.csv` and retrieves block timestamps via pandas-gbq."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import pandas_gbq\n",
+    "\n",
+    "seeds = pd.read_csv('../data/input/seeds.csv', header=None, names=['txid'])\n",
+    "tx_str = ','.join(f'\"{t}\"' for t in seeds['txid'].tolist())\n",
+    "query = f\"\"\"\nSELECT TO_HEX(`hash`) AS txid, block_timestamp\nFROM `bigquery-public-data.crypto_bitcoin.transactions`\nWHERE TO_HEX(`hash`) IN ({tx_str})\n\"\"\"\n",
+    "project_id = pandas_gbq.context.project\n",
+    "timestamps = pandas_gbq.read_gbq(query, project_id=project_id)\n",
+    "timestamps.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/variation4_rest_api.ipynb
+++ b/notebooks/variation4_rest_api.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BigQuery Timestamp Fetch (REST API)\n",
+    "Reads `data/input/seeds.csv` and retrieves block timestamps using the BigQuery REST API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import requests\n",
+    "from google.auth import default\n",
+    "from google.auth.transport.requests import Request\n",
+    "\n",
+    "seeds = pd.read_csv('../data/input/seeds.csv', header=None)[0].tolist()\n",
+    "credentials, project_id = default(scopes=[\"https://www.googleapis.com/auth/bigquery\"])\n",
+    "credentials.refresh(Request())\n",
+    "access_token = credentials.token\n",
+    "sql = \"\"\"\nSELECT TO_HEX(`hash`) AS txid, block_timestamp\nFROM `bigquery-public-data.crypto_bitcoin.transactions`\nWHERE TO_HEX(`hash`) IN UNNEST(@txids)\n\"\"\"\n",
+    "body = {\n  \"query\": sql,\n  \"useLegacySql\": False,\n  \"parameterMode\": \"NAMED\",\n  \"queryParameters\": [\n    {\"name\": \"txids\", \"parameterType\": {\"type\": \"ARRAY\", \"arrayType\": {\"type\": \"STRING\"}},\n     \"parameterValue\": {\"arrayValues\": [{\"value\": t} for t in seeds]}}\n  ]\n}\n",
+    "response = requests.post(\n    f\"https://bigquery.googleapis.com/bigquery/v2/projects/{project_id}/queries\",\n    headers={\"Authorization\": f\"Bearer {access_token}\"},\n    json=body,\n)\n",
+    "rows = response.json().get(\"rows\", [])\n",
+    "timestamps = {r['f'][0]['v']: r['f'][1]['v'] for r in rows}\n",
+    "pd.DataFrame(list(timestamps.items()), columns=['txid','timestamp']).head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add four BigQuery notebook approaches to resolve seed txids to block timestamps
  - bq_utils helper
  - direct SQL with BigQuery client
  - pandas-gbq
  - direct REST API

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b7a2dbe83083328412abf53d58c822