### PR TITLE
Add BigQuery seed timestamp notebooks

### DIFF
--- a/notebooks/BQ_client_array.ipynb
+++ b/notebooks/BQ_client_array.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use BigQuery Client with array parameter to fetch block timestamps\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from google.cloud import bigquery\n",
+    "\n",
+    "seeds = pd.read_csv('../data/input/seeds.csv')\n",
+    "client = bigquery.Client()\n",
+    "query = '''\n",
+    "SELECT t.hash AS txid, b.timestamp AS block_timestamp\n",
+    "FROM `bigquery-public-data.crypto_bitcoin.transactions` AS t\n",
+    "JOIN `bigquery-public-data.crypto_bitcoin.blocks` AS b\n",
+    "ON t.block_id = b.number\n",
+    "WHERE t.hash IN UNNEST(@txids)\n",
+    "'''\n",
+    "job_config = bigquery.QueryJobConfig(\n",
+    "    query_parameters=[bigquery.ArrayQueryParameter('txids', 'STRING', seeds['txid'].tolist())]\n",
+    ")\n",
+    "result_df = client.query(query, job_config=job_config).to_dataframe()\n",
+    "result_df.head()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/BQ_magic.ipynb
+++ b/notebooks/BQ_magic.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use BigQuery magic to fetch block timestamps\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "%load_ext google.cloud.bigquery\n",
+    "\n",
+    "seeds = pd.read_csv('../data/input/seeds.csv')\n",
+    "txids = ','.join(f"'{{tx}}'" for tx in seeds['txid'])\n",
+    "query = f'''\n",
+    "SELECT t.hash AS txid, b.timestamp AS block_timestamp\n",
+    "FROM `bigquery-public-data.crypto_bitcoin.transactions` AS t\n",
+    "JOIN `bigquery-public-data.crypto_bitcoin.blocks` AS b\n",
+    "ON t.block_id = b.number\n",
+    "WHERE t.hash IN ({txids})\n",
+    "'''\n",
+    "result_df = %bigquery query\n",
+    "result_df.head()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/BQ_pandas_gbq.ipynb
+++ b/notebooks/BQ_pandas_gbq.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use pandas-gbq to fetch block timestamps\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import pandas_gbq\n",
+    "\n",
+    "seeds = pd.read_csv('../data/input/seeds.csv')\n",
+    "txids = ','.join(f"'{{tx}}'" for tx in seeds['txid'])\n",
+    "query = f'''\n",
+    "SELECT t.hash AS txid, b.timestamp AS block_timestamp\n",
+    "FROM `bigquery-public-data.crypto_bitcoin.transactions` AS t\n",
+    "JOIN `bigquery-public-data.crypto_bitcoin.blocks` AS b\n",
+    "ON t.block_id = b.number\n",
+    "WHERE t.hash IN ({txids})\n",
+    "'''\n",
+    "result_df = pandas_gbq.read_gbq(query)\n",
+    "result_df.head()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/BQ_rest_api.ipynb
+++ b/notebooks/BQ_rest_api.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use BigQuery REST API to fetch block timestamps\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import google.auth\n",
+    "import google.auth.transport.requests\n",
+    "import requests\n",
+    "\n",
+    "seeds = pd.read_csv('../data/input/seeds.csv')\n",
+    "credentials, project = google.auth.default(scopes=['https://www.googleapis.com/auth/bigquery'])\n",
+    "credentials.refresh(google.auth.transport.requests.Request())\n",
+    "headers = {'Authorization': f'Bearer {credentials.token}', 'Content-Type': 'application/json'}\n",
+    "query = '''\n",
+    "SELECT t.hash AS txid, b.timestamp AS block_timestamp\n",
+    "FROM `bigquery-public-data.crypto_bitcoin.transactions` AS t\n",
+    "JOIN `bigquery-public-data.crypto_bitcoin.blocks` AS b\n",
+    "ON t.block_id = b.number\n",
+    "WHERE t.hash IN UNNEST(@txids)\n",
+    "'''\n",
+    "body = {\n",
+    "    'query': query,\n",
+    "    'useLegacySql': False,\n",
+    "    'parameterMode': 'NAMED',\n",
+    "    'queryParameters': [{\n",
+    "        'name': 'txids',\n",
+    "        'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'STRING'}},\n",
+    "        'parameterValue': {'arrayValues': [{'value': tx} for tx in seeds['txid'].tolist()]}\n",
+    "    }]\n",
+    "}\n",
+    "response = requests.post(
+        f'https://bigquery.googleapis.com/bigquery/v2/projects/{project}/queries',
+        headers=headers, json=body
+    )\n",
+    "rows = response.json().get('rows', [])\n",
+    "result_df = pd.DataFrame([{'txid': r['f'][0]['v'], 'block_timestamp': r['f'][1]['v']} for r in rows])\n",
+    "result_df.head()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add BigQuery client notebook using array parameters to fetch block timestamps
- add pandas-gbq notebook for querying block timestamps
- add BigQuery magic notebook utilizing `%bigquery`
- add BigQuery REST API notebook for block timestamp lookup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7a2dbe83083328412abf53d58c822