### PR TITLE
Add seed timestamp BigQuery notebooks

### DIFF
--- a/notebooks/seed_bq_direct.ipynb
+++ b/notebooks/seed_bq_direct.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Direct BigQuery client query\n",
+    "\n",
+    "Reads `data/input/seeds.csv` and performs a parameterized `IN UNNEST` query using `google.cloud.bigquery` directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import pandas as pd\n",
+    "from google.cloud import bigquery\n",
+    "\n",
+    "BASE = Path.cwd().parent\n",
+    "INPUT_DIR = BASE / 'data' / 'input'\n",
+    "df = pd.read_csv(INPUT_DIR / 'seeds.csv')\n",
+    "txids = df['txid'].dropna().tolist()\n",
+    "len(txids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = bigquery.Client()\n",
+    "sql = (\n",
+    "    \"SELECT TO_HEX(`hash`) AS txid, block_timestamp\\n\"\n",
+    "    \"FROM `bigquery-public-data.crypto_bitcoin.transactions`\\n\"\n",
+    "    \"WHERE TO_HEX(`hash`) IN UNNEST(@txid_list)\\n\"\n",
+    ")\n",
+    "job_config = bigquery.QueryJobConfig(query_parameters=[bigquery.ArrayQueryParameter('txid_list', 'STRING', txids)])\n",
+    "rows = client.query(''.join(sql), job_config=job_config).result()\n",
+    "result_map = {row['txid']: row['block_timestamp'] for row in rows}\n",
+    "df['block_timestamp'] = df['txid'].map(result_map)\n",
+    "df.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/seed_bq_helper.ipynb
+++ b/notebooks/seed_bq_helper.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fetch block timestamps with helper\n",
+    "\n",
+    "Reads `data/input/seeds.csv` and uses `bq_utils.fetch_tx_timestamps` to get block timestamps from the BigQuery public Bitcoin dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import sys\n",
+    "import pandas as pd\n",
+    "\n",
+    "BASE = Path.cwd().parent\n",
+    "INPUT_DIR = BASE / 'data' / 'input'\n",
+    "sys.path.append(str((BASE / 'src').resolve()))\n",
+    "from bq_utils import get_bigquery_client, fetch_tx_timestamps\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(INPUT_DIR / 'seeds.csv')\n",
+    "txids = df['txid'].dropna().tolist()\n",
+    "len(txids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = get_bigquery_client()\n",
+    "ts_map = fetch_tx_timestamps(client, txids)\n",
+    "df['block_timestamp'] = df['txid'].map(ts_map)\n",
+    "df.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/seed_bq_magic.ipynb
+++ b/notebooks/seed_bq_magic.ipynb
@@ -1,0 +1,64 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BigQuery magic example\n",
+    "\n",
+    "Demonstrates the `%%bigquery` Jupyter cell magic to fetch block timestamps for txids in `data/input/seeds.csv`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext google.cloud.bigquery\n",
+    "from pathlib import Path\n",
+    "import pandas as pd\n",
+    "\n",
+    "BASE = Path.cwd().parent\n",
+    "INPUT_DIR = BASE / 'data' / 'input'\n",
+    "df = pd.read_csv(INPUT_DIR / 'seeds.csv')\n",
+    "txids = df['txid'].dropna().tolist()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bigquery result_df --params {\"txid_list\": txids}\n",
+    "SELECT TO_HEX(`hash`) AS txid, block_timestamp\n",
+    "FROM `bigquery-public-data.crypto_bitcoin.transactions`\n",
+    "WHERE TO_HEX(`hash`) IN UNNEST(@txid_list)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.merge(result_df, on='txid', how='left')\n",
+    "df.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/seed_bq_pandas_gbq.ipynb
+++ b/notebooks/seed_bq_pandas_gbq.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Query with pandas_gbq\n",
+    "\n",
+    "Uses `pandas_gbq.read_gbq` to fetch block timestamps for txids listed in `data/input/seeds.csv`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import pandas as pd\n",
+    "import pandas_gbq\n",
+    "\n",
+    "BASE = Path.cwd().parent\n",
+    "INPUT_DIR = BASE / 'data' / 'input'\n",
+    "df = pd.read_csv(INPUT_DIR / 'seeds.csv')\n",
+    "txids = df['txid'].dropna().tolist()\n",
+    "txids[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "txids_str = ','.join(f\"'{{t}}'\" for t in txids)\n",
+    "query = f'''\nSELECT TO_HEX(`hash`) AS txid, block_timestamp\nFROM `bigquery-public-data.crypto_bitcoin.transactions`\nWHERE TO_HEX(`hash`) IN ({txids_str})\n'''\n",
+    "result = pandas_gbq.read_gbq(query)\n",
+    "df = df.merge(result, on='txid', how='left')\n",
+    "df.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add helper-based notebook to fetch block timestamps for seeds.csv
- add direct BigQuery client notebook
- add pandas_gbq example notebook
- add BigQuery magic notebook

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7a2dbe83083328412abf53d58c822