### PR TITLE
Add BigQuery timestamp lookup notebooks

### DIFF
--- a/notebooks/Seeds_BQ_Client.ipynb
+++ b/notebooks/Seeds_BQ_Client.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Query seeds.csv with BigQuery client\n\nUses google-cloud-bigquery client and helper util."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "\nfrom pathlib import Path\nimport pandas as pd\nfrom bq_utils import get_bigquery_client, fetch_tx_timestamps\n\nbase = Path('..').resolve()\nseeds = pd.read_csv(base / 'data' / 'input' / 'seeds.csv')\ntxids = seeds['txid'].dropna().tolist()\n\nclient = get_bigquery_client()\ntimestamps = fetch_tx_timestamps(client, txids)\npd.DataFrame(list(timestamps.items()), columns=['txid', 'block_timestamp'])\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Seeds_BQ_Magic.ipynb
+++ b/notebooks/Seeds_BQ_Magic.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Query seeds.csv using BigQuery magic\n\nUses the %%bigquery IPython magic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "\nfrom pathlib import Path\nimport pandas as pd\nfrom google.cloud import bigquery\nfrom IPython import get_ipython\n\nbase = Path('..').resolve()\nseeds = pd.read_csv(base / 'data' / 'input' / 'seeds.csv')\ntxids = seeds['txid'].dropna().tolist()\n\nipython = get_ipython()\nipython.run_line_magic('load_ext', 'google.cloud.bigquery')\n# parameters are passed as JSON string\nparams = {'txid_list': txids}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "\n%%bigquery result --params {\"txid_list\": txids}\nSELECT TO_HEX(`hash`) AS txid, block_timestamp\nFROM `bigquery-public-data.crypto_bitcoin.transactions`\nWHERE TO_HEX(`hash`) IN UNNEST(@txid_list)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Seeds_BQ_REST.ipynb
+++ b/notebooks/Seeds_BQ_REST.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Query seeds.csv via BigQuery REST API\n\nUses requests with google.auth credentials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "\nfrom pathlib import Path\nimport json\nimport pandas as pd\nimport requests\nimport google.auth\nfrom google.auth.transport.requests import Request\n\nbase = Path('..').resolve()\nseeds = pd.read_csv(base / 'data' / 'input' / 'seeds.csv')\ntxids = seeds['txid'].dropna().tolist()\n\ncredentials, project_id = google.auth.default()\ncredentials.refresh(Request())\nheaders = {'Authorization': f'Bearer {credentials.token}'}\n\nsql = {\n    'query': \"\"\"\n        SELECT TO_HEX(`hash`) AS txid, block_timestamp\n        FROM `bigquery-public-data.crypto_bitcoin.transactions`\n        WHERE TO_HEX(`hash`) IN UNNEST(@txid_list)\n    \"\"\",\n    'useLegacySql': False,\n    'queryParameters': [\n        {\n            'name': 'txid_list',\n            'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'STRING'}},\n            'parameterValue': {'arrayValues': [{'value': t} for t in txids]}\n        }\n    ]\n}\n\nurl = f'https://bigquery.googleapis.com/bigquery/v2/projects/{project_id}/queries'\nresp = requests.post(url, headers=headers, json=sql)\nrows = resp.json().get('rows', [])\ndata = [(r['f'][0]['v'], r['f'][1]['v']) for r in rows]\npd.DataFrame(data, columns=['txid', 'block_timestamp'])\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Seeds_Pandas_GBQ.ipynb
+++ b/notebooks/Seeds_Pandas_GBQ.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Query seeds.csv using pandas-gbq\n\nRuns a parameterised SQL query with pandas_gbq.read_gbq."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "\nfrom pathlib import Path\nimport pandas as pd\nimport pandas_gbq\n\nbase = Path('..').resolve()\nseeds = pd.read_csv(base / 'data' / 'input' / 'seeds.csv')\ntxids = seeds['txid'].dropna().tolist()\n\nsql = \"\"\"\nSELECT TO_HEX(`hash`) AS txid, block_timestamp\nFROM `bigquery-public-data.crypto_bitcoin.transactions`\nWHERE TO_HEX(`hash`) IN UNNEST(@txid_list)\n\"\"\"\ndf = pandas_gbq.read_gbq(sql, project_id=None, location='US', params={'txid_list': txids})\ndf\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add four notebook variants for fetching Bitcoin transaction timestamps from seeds.csv via BigQuery
  - BigQuery client helper
  - pandas-gbq
  - BigQuery IPython magic
  - BigQuery REST API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7a2dbe83083328412abf53d58c822